### PR TITLE
Replace links to dfe-digital with x-govuk

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # GOV.UK Design System Form Builder for Rails
 
-[![Tests](https://github.com/DFE-Digital/govuk-formbuilder/workflows/Tests/badge.svg)](https://github.com/DFE-Digital/govuk-formbuilder/actions)
-[![Maintainability](https://api.codeclimate.com/v1/badges/110136fb22341d3ba646/maintainability)](https://codeclimate.com/github/DFE-Digital/govuk-formbuilder/maintainability)
+[![Tests](https://github.com/x-govuk/govuk-formbuilder/workflows/Tests/badge.svg)](https://github.com/x-govuk/govuk-formbuilder/actions)
+[![Maintainability](https://api.codeclimate.com/v1/badges/110136fb22341d3ba646/maintainability)](https://codeclimate.com/github/x-govuk/govuk-formbuilder/maintainability)
 [![Gem Version](https://badge.fury.io/rb/govuk_design_system_formbuilder.svg)](https://badge.fury.io/rb/govuk_design_system_formbuilder)
 [![Gem](https://img.shields.io/gem/dt/govuk_design_system_formbuilder?logo=rubygems)](https://rubygems.org/gems/govuk_design_system_formbuilder)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/110136fb22341d3ba646/test_coverage)](https://codeclimate.com/github/DFE-Digital/govuk-formbuilder/test_coverage)
-[![GitHub license](https://img.shields.io/github/license/DFE-Digital/govuk_design_system_formbuilder)](https://github.com/DFE-Digital/govuk-formbuilder/blob/main/LICENSE)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/110136fb22341d3ba646/test_coverage)](https://codeclimate.com/github/x-govuk/govuk-formbuilder/test_coverage)
+[![GitHub license](https://img.shields.io/github/license/x-govuk/govuk_design_system_formbuilder)](https://github.com/x-govuk/govuk-formbuilder/blob/main/LICENSE)
 [![GOV.UK Design System Version](https://img.shields.io/badge/GOV.UK%20Design%20System-4.6.0-brightgreen)](https://design-system.service.gov.uk)
 [![Rails](https://img.shields.io/badge/Rails-6.1.7%20%E2%95%B1%207.0.4-E16D6D)](https://weblog.rubyonrails.org/releases/)
 [![Ruby](https://img.shields.io/badge/Ruby-3.0.5%20%20%E2%95%B1%203.1.3%20%20%E2%95%B1%203.2.0-E16D6D)](https://www.ruby-lang.org/en/downloads/)
@@ -130,13 +130,13 @@ git config --global user.name "Julius Hibbert"
 
 ## Services using this library
 
-Approximately [100 services use this library](https://github.com/DFE-Digital/govuk-formbuilder/network/dependents),
+Approximately [100 services use this library](https://github.com/x-govuk/govuk-formbuilder/network/dependents),
 here are a few from the <abbr title="Department for Education">DfE</abbr>, <abbr title="Ministry of Justice">MoJ</abbr>, and
 <abbr title="Department for Business, Energy & Industrial Strategy">BEIS</abbr>.
 
- * [Apply for teacher training](https://www.github.com/DFE-Digital/apply-for-teacher-training)
- * [Teaching Vacancies](https://www.github.com/DFE-Digital/teaching-vacancies)
- * [Get a teacher training adviser](https://www.github.com/DFE-Digital/get-teacher-training-adviser-service/)
+ * [Apply for teacher training](https://www.github.com/x-govuk/apply-for-teacher-training)
+ * [Teaching Vacancies](https://www.github.com/x-govuk/teaching-vacancies)
+ * [Get a teacher training adviser](https://www.github.com/x-govuk/get-teacher-training-adviser-service/)
  * [Claim for crown court defence](https://www.github.com/ministryofjustice/Claim-for-Crown-Court-Defence)
  * [Appeal to the tax tribunal](https://www.github.com/ministryofjustice/tax-tribunals-datacapture)
  * [Apply to court about child arrangements](https://www.github.com/ministryofjustice/c100-application)

--- a/govuk_design_system_formbuilder.gemspec
+++ b/govuk_design_system_formbuilder.gemspec
@@ -4,12 +4,12 @@ require "govuk_design_system_formbuilder/version"
 require_relative "util/version_formatter"
 
 METADATA = {
-  "bug_tracker_uri"   => "https://github.com/DFE-Digital/govuk-formbuilder/issues",
-  "changelog_uri"     => "https://github.com/DFE-Digital/govuk-formbuilder/releases",
+  "bug_tracker_uri"   => "https://github.com/x-govuk/govuk-formbuilder/issues",
+  "changelog_uri"     => "https://github.com/x-govuk/govuk-formbuilder/releases",
   "documentation_uri" => "https://www.rubydoc.info/gems/govuk_design_system_formbuilder/GOVUKDesignSystemFormBuilder/Builder",
   "homepage_uri"      => "https://govuk-form-builder.netlify.app",
-  "source_code_uri"   => "https://github.com/DFE-Digital/govuk-formbuilder",
-  "github_repo"       => "https://github.com/DFE-Digital/govuk-formbuilder"
+  "source_code_uri"   => "https://github.com/x-govuk/govuk-formbuilder",
+  "github_repo"       => "https://github.com/x-govuk/govuk-formbuilder"
 }.freeze
 
 Gem::Specification.new do |s|

--- a/guide/lib/helpers/link_helpers.rb
+++ b/guide/lib/helpers/link_helpers.rb
@@ -7,7 +7,7 @@ module Helpers
 
   module LinkHelpers
     def code_climate_report_link
-      'https://codeclimate.com/github/DFE-Digital/govuk_design_system_formbuilder'
+      'https://codeclimate.com/github/x-govuk/govuk-formbuilder'
     end
 
     def documentation_link
@@ -19,11 +19,11 @@ module Helpers
     end
 
     def github_link
-      'https://github.com/DFE-Digital/govuk-formbuilder'
+      'https://github.com/x-govuk/govuk-formbuilder'
     end
 
     def github_release_2_8_0
-      'https://github.com/DFE-Digital/govuk-formbuilder/releases/tag/v2.8.0'
+      'https://github.com/x-govuk/govuk-formbuilder/releases/tag/v2.8.0'
     end
 
     def design_system_link
@@ -79,7 +79,7 @@ module Helpers
     end
 
     def project_new_issue_link
-      'https://github.com/DFE-Digital/govuk-formbuilder/issues'
+      'https://github.com/x-govuk/govuk-formbuilder/issues'
     end
 
     def nhs_design_system_link


### PR DESCRIPTION
The redirects are causing Nanoc's link checker to fail and preventing changes to the guide being published.